### PR TITLE
Update to web3j v4.3.0 and other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Before you start, you will need to install the
 [Solidity compiler](https://solidity.readthedocs.io/en/latest/installing-solidity.html)
 if is not already installed in your computer.
 
-In addition, the minimum Gradle version to run the plugin is `4.9` and the recommended `5.2.x`.
+In addition, the minimum Gradle version to run the plugin is `4.9` and the recommended `5.4.x`.
 
 ### Using the `buildscript` convention
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.web3j:web3j-gradle-plugin:4.1.3'
+        classpath 'org.web3j:web3j-gradle-plugin:4.3.0'
     }
 }
 
@@ -39,7 +39,7 @@ build file:
 
 ```groovy
 plugins {
-    id 'org.web3j' version '4.1.3'
+    id 'org.web3j' version '4.3.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ jacocoTestReport {
 }
 
 ext {
-    web3jVersion = '4.1.1'
-    solidityPluginVersion = '0.1.4'
+    web3jVersion = '4.3.0'
+    solidityPluginVersion = '0.1.5-SNAPSHOT'
     junitVersion = '4.12'
 
     ossrhUsername = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : System.getenv('OSSRH_USERNAME')
@@ -44,6 +44,7 @@ ext {
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ jacocoTestReport {
 
 ext {
     web3jVersion = '4.3.0'
-    solidityPluginVersion = '0.1.5-SNAPSHOT'
+    solidityPluginVersion = '0.1.6'
     junitVersion = '4.12'
 
     ossrhUsername = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : System.getenv('OSSRH_USERNAME')

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ ext {
 
 repositories {
     mavenCentral()
-    mavenLocal()
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=org.web3j
-version=4.3.0-SNAPSHOT
+version=4.3.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=org.web3j
-version=4.1.3
+version=4.3.0-SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/src/main/java/org/web3j/gradle/plugin/Web3jPlugin.java
+++ b/src/main/java/org/web3j/gradle/plugin/Web3jPlugin.java
@@ -33,6 +33,7 @@ public class Web3jPlugin implements Plugin<Project> {
         target.getPluginManager().apply(JavaPlugin.class);
         target.getPluginManager().apply(SolidityPlugin.class);
         target.getExtensions().create(Web3jExtension.NAME, Web3jExtension.class, target);
+        target.getDependencies().add("implementation", "org.web3j:core:4.3.0");
 
         final SourceSetContainer sourceSets = target.getConvention()
                 .getPlugin(JavaPluginConvention.class).getSourceSets();
@@ -68,8 +69,8 @@ public class Web3jPlugin implements Plugin<Project> {
 
         // Set the sources for the generation task
         task.setSource(buildSourceDirectorySet(sourceSet));
-        task.setDescription("Generates web3j contract wrappers for "
-                + sourceSet.getName() + " source set.");
+        task.setDescription("Generates " + sourceSet.getName()
+                + " Java contract wrappers from Solidity ABIs.");
 
         // Set the task output directory
         task.getOutputs().dir(outputDir);

--- a/src/test/java/org/web3j/gradle/plugin/Web3jPluginTest.java
+++ b/src/test/java/org/web3j/gradle/plugin/Web3jPluginTest.java
@@ -57,9 +57,6 @@ public class Web3jPluginTest {
                 "}\n" +
                 "repositories {\n" +
                 "   mavenCentral()\n" +
-                "}\n" +
-                "dependencies {\n" +
-                "   implementation \"org.web3j:core:4.1.1\"\n" +
                 "}\n";
 
         Files.write(buildFile.toPath(), buildFileContent.getBytes());
@@ -112,9 +109,6 @@ public class Web3jPluginTest {
                 "}\n" +
                 "repositories {\n" +
                 "   mavenCentral()\n" +
-                "}\n" +
-                "dependencies {\n" +
-                "   implementation \"org.web3j:core:4.1.1\"\n" +
                 "}\n";
 
         Files.write(buildFile.toPath(), buildFileContent.getBytes());


### PR DESCRIPTION
This PR updates the Solidity plugin version to support the bundled `solc` compiler and custom `executable`.