### PR TITLE
fix: Use platform independent path separator character

### DIFF
--- a/src/main/java/org/web3j/gradle/plugin/Web3jPlugin.java
+++ b/src/main/java/org/web3j/gradle/plugin/Web3jPlugin.java
@@ -167,7 +167,12 @@ public class Web3jPlugin implements Plugin<Project> {
             throw new InvalidUserDataException("Generated web3j package cannot be empty");
         }
 
-        return new File(extension.getGeneratedFilesBaseDir() + "/" + sourceSet.getName() + "/java");
+        return new File(
+                extension.getGeneratedFilesBaseDir()
+                        + File.pathSeparator
+                        + sourceSet.getName()
+                        + File.pathSeparator
+                        + "java");
     }
 
     protected File buildOutputDir(final SourceSet sourceSet) {


### PR DESCRIPTION
### What does this PR do?
Use platform independent path separator character in generated Java directory path.

### Why is it needed?
Should work on all operating systems.

@xaviarias @AlexandrouR