### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ documentation to configure the smart contracts source code directories.
 Output directories for generated smart contract wrappers Java code 
 will be added to your build automatically.
 
+As already mentioned in [Solidity Plugin](https://github.com/web3j/solidity-gradle-plugin) `README.md`, it makes use 
+of the [Node plugin](https://github.com/node-gradle/gradle-node-plugin) to resolve third-party contract dependencies. 
+So in order to resolve the dependencies a node project structure will be created. To choose for example where the 
+`node_modules` and `.json files` should be placed, or protected by any `clean` task, as it is mentioned on [Solidity Plugin](https://github.com/web3j/solidity-gradle-plugin) 
+add the following snippet to your `build.gradle` file:
+```
+node {
+    nodeProjectDir = file("my/custom/node/directory")
+}
+```
+
 ## Plugin tasks
 
 The [Java Plugin](https://docs.gradle.org/current/userguide/java_plugin.html)


### PR DESCRIPTION
### What does this PR do?
Add additional info to README.md, related to the way in which node_modules dependency resolvers can be placed.

### Where should the reviewer start?
Changed files

### Why is it needed?
Some users don't read the full specs, and by this I mean that they don't get to read the specs of [solidity-gradle-plugin](https://github.com/web3j/solidity-gradle-plugin) which is used by this project.  
If the `nodeProjectDir` property is not set, by default will be placed under `build` folder, so every time a `clean` takes place, related node files will be deleted.
For example if this will be added to the project:
```
node {
    nodeProjectDir.set(file("$rootDir"))
}
```
Files will be kept like this:

![Capture](https://user-images.githubusercontent.com/99179176/159541410-fac9ef23-090b-4dc6-8a2a-7030439f3d1b.PNG)

